### PR TITLE
Multi-Path Pruning BFS queue

### DIFF
--- a/src/main/java/edu/washburn/cis/ichabot/implementation/npuzzle/NPuzzleState.java
+++ b/src/main/java/edu/washburn/cis/ichabot/implementation/npuzzle/NPuzzleState.java
@@ -107,4 +107,12 @@ public class NPuzzleState implements SearchState<NPuzzleAction,NPuzzleState> {
         }
         return ret;
     }
+    @Override
+    public boolean equals(Object state) {
+        return Arrays.deepEquals(puzzleState,((NPuzzleState)state).puzzleState);
+    }
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(puzzleState);
+    }
 }

--- a/src/main/java/edu/washburn/cis/ichabot/search/MPPQueue.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MPPQueue.java
@@ -1,0 +1,23 @@
+package edu.washburn.cis.ichabot.search;
+/*
+A breadth-first search queue using multi-path pruning
+Solves the NPuzzle 300 times faster than a non-pruning breadth-first search queue
+Developed by Ellie Hanson
+*/
+import java.util.*;
+
+public class MPPQueue<SearchStateT extends SearchState,ActionT> extends 
+        LinkedList<SearchPath<SearchStateT,ActionT>> {
+    private Set<SearchStateT> explored = new HashSet<SearchStateT>();
+    
+    @Override
+    public SearchPath<SearchStateT,ActionT> poll() {
+        while(true) {
+            var selected = super.poll();
+            if(!explored.contains(selected.STATE)) {
+                explored.add(selected.STATE);
+                return selected;
+            }
+        }        
+    }
+}


### PR DESCRIPTION
Hi Dr. J, this is the pruner I developed in unit 2, which you asked me to consider a pull request for.
The pull request includes a class, MPPQueue.java, for the actual pruner, and some method overrides for NPuzzleState that are needed for it to work correctly with that.
I have only tested it with the NPuzzle, but the MPPQueue solves it at least 300 times faster than the default non-pruning breadth-first searcher.