### PR TITLE
MCTS Implementation for the Ichabot Search Package

### DIFF
--- a/src/main/java/edu/washburn/cis/ichabot/implementation/reversi/ReversiPlayground.java
+++ b/src/main/java/edu/washburn/cis/ichabot/implementation/reversi/ReversiPlayground.java
@@ -1,6 +1,7 @@
 package edu.washburn.cis.ichabot.implementation.reversi;
 
-import edu.washburn.cis.ichabot.search.*;
+import edu.washburn.cis.ichabot.search.MCTS;
+import edu.washburn.cis.ichabot.search.Searcher;
 
 public class ReversiPlayground {
 
@@ -12,10 +13,17 @@ public class ReversiPlayground {
         long startTime = System.currentTimeMillis();
         
         //var action = Searcher.minimaxSearch(state);
-        var action = Searcher.alphaBetaSearch(state, s->0.0, 14);
+        //var action = Searcher.alphaBetaSearch(state, s->0.0, 14);
 
-        /*
-        while(state != null) {
+        MCTS<ReversiAction, ReversiState> searcher = new MCTS<>(
+            s->s.evaluate(), 
+            1.414, 
+            1000
+            );
+        var action = searcher.findBestAction(state);
+
+        /* 
+        while(state != null && !state.isLeaf()) {
             System.out.println(state);
             boolean a = false;
             for(var s2: state.children()) {
@@ -25,7 +33,8 @@ public class ReversiPlayground {
             }
             if(!a) break;
         }
- */
+        */
+ 
         long endTime = System.currentTimeMillis();
         System.out.println("Expansions: " + ReversiState.expansions);
         System.out.println("Time: " + (endTime - startTime));

--- a/src/main/java/edu/washburn/cis/ichabot/implementation/reversi/ReversiState.java
+++ b/src/main/java/edu/washburn/cis/ichabot/implementation/reversi/ReversiState.java
@@ -140,4 +140,11 @@ public class ReversiState extends MinimaxSearchState<ReversiAction,ReversiState>
         }
         return b.toString();
     }
+
+    //we are in a leaf node if there are no legal moves for either player
+    @Override
+    public boolean isLeaf() {
+        return (actions().iterator().next().SKIP) 
+            && (this.nextState(actions().iterator().next()).actions().iterator().next().SKIP);
+    }
 }

--- a/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
@@ -1,0 +1,103 @@
+package edu.washburn.cis.ichabot.search;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Function;
+
+public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchStateT>> {
+    private final Function<SearchStateT, Double> evaluator;
+    private final double explorationParameter;
+    private final int maxIterations;
+
+    public MCTS(Function<SearchStateT, Double> evaluator, double explorationParameter, int maxIterations) {
+        this.evaluator = evaluator;
+        this.explorationParameter = explorationParameter;
+        this.maxIterations = maxIterations;
+    }
+
+    public ActionT findBestAction(SearchStateT initialState) {
+        MCTSNode<ActionT, SearchStateT> root = new MCTSNode<>(initialState);
+
+        for (int i = 0; i < maxIterations; i++) {
+            System.out.println("Iteration " + i);
+            MCTSNode<ActionT, SearchStateT> selectedNode = select(root);
+            MCTSNode<ActionT, SearchStateT> expandedNode = expand(selectedNode);
+            double result = simulate(expandedNode);
+            backpropagate(expandedNode, result);
+        }
+
+        return getBestAction(root);
+    }
+
+    private MCTSNode<ActionT, SearchStateT> select(MCTSNode<ActionT, SearchStateT> node) {
+        System.out.println("Selecting...");
+        while (!node.state.isLeaf()) {
+            if (!node.isFullyExpanded()) {
+                return node;
+            } else {
+                node = selectBestChild(node);
+            }
+        }
+        return node;
+    }
+
+    private MCTSNode<ActionT, SearchStateT> selectBestChild(MCTSNode<ActionT, SearchStateT> node) {
+        return node.children.values().stream()
+                .max(Comparator.comparingDouble(child -> ucb1(node, child)))
+                .orElseThrow();
+    }
+
+    private double ucb1(MCTSNode<ActionT, SearchStateT> parent, MCTSNode<ActionT, SearchStateT> child) {
+        if (child.visitCount == 0) return Double.POSITIVE_INFINITY;
+        return child.getAverageValue() +
+                explorationParameter * Math.sqrt(Math.log(parent.visitCount) / child.visitCount);
+    }
+
+    private MCTSNode<ActionT, SearchStateT> expand(MCTSNode<ActionT, SearchStateT> node) {
+        System.out.println("Expanding...");
+        if (node.state.isLeaf()) return node;
+
+        for (ActionT action : node.state.actions()) {
+            if (!node.children.containsKey(action)) {
+                SearchStateT childState = node.state.nextState(action);
+                MCTSNode<ActionT, SearchStateT> childNode = new MCTSNode<>(childState, node, action);
+                node.addChild(action, childNode);
+                return childNode;
+            }
+        }
+        return node; // Shouldn't reach here if isFullyExpanded checked
+    }
+
+    private double simulate(MCTSNode<ActionT, SearchStateT> node) {
+        System.out.println("Simulating...");
+        SearchStateT currentState = node.state;
+        Random rand = new Random();
+
+        while (!currentState.isLeaf()) {
+            List<ActionT> actions = new ArrayList<>(currentState.actions());
+            ActionT action = actions.get(rand.nextInt(actions.size()));
+            currentState = currentState.nextState(action);
+        }
+
+        return evaluator.apply(currentState);
+    }
+
+    private void backpropagate(MCTSNode<ActionT, SearchStateT> node, double result) {
+        System.out.println("Backpropagating...");
+        while (node != null) {
+            node.visitCount++;
+            node.totalValue += result;
+            node = node.parent;
+        }
+    }
+
+    private ActionT getBestAction(MCTSNode<ActionT, SearchStateT> root) {
+        return root.children.entrySet().stream()
+                .max(Comparator.comparingInt(e -> e.getValue().visitCount))
+                .map(Map.Entry::getKey)
+                .orElse(null);
+    }
+}

--- a/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
@@ -48,7 +48,6 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         MCTSNode<ActionT, SearchStateT> root = new MCTSNode<>(initialState);
 
         for (int i = 0; i < maxIterations; i++) {
-            System.out.println("Iteration " + i);
             MCTSNode<ActionT, SearchStateT> selectedNode = select(root);
             MCTSNode<ActionT, SearchStateT> expandedNode = expand(selectedNode);
             double result = simulate(expandedNode);
@@ -68,7 +67,6 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
      */
 
     private MCTSNode<ActionT, SearchStateT> select(MCTSNode<ActionT, SearchStateT> node) {
-        System.out.println("Selecting...");
         while (!node.state.isLeaf()) {
             if (!node.isFullyExpanded()) {
                 return node;
@@ -127,7 +125,6 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
      *         visited.
      */
     private MCTSNode<ActionT, SearchStateT> expand(MCTSNode<ActionT, SearchStateT> node) {
-        System.out.println("Expanding...");
         if (node.state.isLeaf()) return node;
 
         for (ActionT action : node.state.actions()) {
@@ -151,7 +148,6 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
      * @return The value of the leaf node reached by the simulation.
      */
     private double simulate(MCTSNode<ActionT, SearchStateT> node) {
-        System.out.println("Simulating...");
         SearchStateT currentState = node.state;
         Random rand = new Random();
 
@@ -174,7 +170,6 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
      * @param result The value of the leaf node.
      */
     private void backpropagate(MCTSNode<ActionT, SearchStateT> node, double result) {
-        System.out.println("Backpropagating...");
         while (node != null) {
             node.visitCount++;
             node.totalValue += result;

--- a/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MCTS.java
@@ -7,16 +7,42 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.Function;
 
+/**
+ * A simple implementation of the MCTS algorithm
+ * Should work for any state and action that properly extends SearchState,
+ * Including states that extend MinimaxSearchState.
+ * 
+ * @author Hayden Eddy
+ * @version 1.0
+ * @see MCTSNode
+ */
 public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchStateT>> {
     private final Function<SearchStateT, Double> evaluator;
     private final double explorationParameter;
     private final int maxIterations;
 
+    /**
+     * Constructor
+     * @param evaluator A function that evaluates the value of a state
+     * @param explorationParameter The exploration parameter. Ideally set to sqrt(2)
+     * @param maxIterations The maximum number of iterations. Typically 1000
+     */
     public MCTS(Function<SearchStateT, Double> evaluator, double explorationParameter, int maxIterations) {
         this.evaluator = evaluator;
         this.explorationParameter = explorationParameter;
         this.maxIterations = maxIterations;
     }
+
+    /**
+     * Executes the Monte Carlo Tree Search (MCTS) algorithm to find the best action
+     * from a given initial state. The search is performed over a specified number 
+     * of iterations, where each iteration consists of selection, expansion, simulation, 
+     * and backpropagation phases. The function returns the action associated with 
+     * the child node of the root having the highest average reward.
+     *
+     * @param initialState The initial state from which the search begins.
+     * @return The best action found after the specified number of iterations.
+     */
 
     public ActionT findBestAction(SearchStateT initialState) {
         MCTSNode<ActionT, SearchStateT> root = new MCTSNode<>(initialState);
@@ -32,6 +58,15 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         return getBestAction(root);
     }
 
+    /**
+     * Selects a node to expand by traversing the tree from the given node.
+     * The selection is based on the UCB1 value, moving towards the best child
+     * until a leaf node or a non-fully expanded node is reached.
+     *
+     * @param node The starting node for the selection process.
+     * @return The selected node for expansion.
+     */
+
     private MCTSNode<ActionT, SearchStateT> select(MCTSNode<ActionT, SearchStateT> node) {
         System.out.println("Selecting...");
         while (!node.state.isLeaf()) {
@@ -44,18 +79,53 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         return node;
     }
 
+/**
+ * Selects the best child of the given node based on the UCB1 value.
+ * Iterates over all children and returns the one with the highest score.
+ *
+ * @param node The parent node whose children are to be evaluated.
+ * @return The child node with the highest UCB1 value.
+ * @throws NoSuchElementException if the node has no children.
+ */
+
     private MCTSNode<ActionT, SearchStateT> selectBestChild(MCTSNode<ActionT, SearchStateT> node) {
         return node.children.values().stream()
                 .max(Comparator.comparingDouble(child -> ucb1(node, child)))
                 .orElseThrow();
     }
 
+    /**
+     * Calculates the UCB1 value for the given child node.
+     * The UCB1 value is a heuristic that balances exploration and exploitation.
+     * It is the average value of the child node plus a bonus term that depends
+     * on the number of visits to the child and its parent node.
+     *
+     * The bonus term is a function of the logarithm of the number of visits to the
+     * parent node divided by the number of visits to the child node, scaled by
+     * the exploration parameter.
+     *
+     * If the child node has not been visited before, the UCB1 value is set to
+     * positive infinity, so that the child is chosen as the best node.
+     *
+     * @param parent The parent node of the child node.
+     * @param child The child node for which to calculate the UCB1 value.
+     * @return The UCB1 value of the child node.
+     */
     private double ucb1(MCTSNode<ActionT, SearchStateT> parent, MCTSNode<ActionT, SearchStateT> child) {
         if (child.visitCount == 0) return Double.POSITIVE_INFINITY;
         return child.getAverageValue() +
                 explorationParameter * Math.sqrt(Math.log(parent.visitCount) / child.visitCount);
     }
 
+    /**
+     * Expands the given node by adding a new child node for a random unvisited
+     * action, if such an action exists. If all actions have been visited, returns
+     * the node as is.
+     *
+     * @param node The node to expand.
+     * @return The expanded node, or the original node if all actions have been
+     *         visited.
+     */
     private MCTSNode<ActionT, SearchStateT> expand(MCTSNode<ActionT, SearchStateT> node) {
         System.out.println("Expanding...");
         if (node.state.isLeaf()) return node;
@@ -71,6 +141,15 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         return node; // Shouldn't reach here if isFullyExpanded checked
     }
 
+    /**
+     * Simulates a random playout from the given node to a leaf node.
+     * The simulation is done by randomly selecting an action from the
+     * current state's actions until a leaf node is reached.
+     * The value of the leaf node is then returned.
+     *
+     * @param node The node to start the simulation from.
+     * @return The value of the leaf node reached by the simulation.
+     */
     private double simulate(MCTSNode<ActionT, SearchStateT> node) {
         System.out.println("Simulating...");
         SearchStateT currentState = node.state;
@@ -85,6 +164,15 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         return evaluator.apply(currentState);
     }
 
+    /**
+     * Backpropagates the result of a simulation to the root node.
+     * The value of the leaf node is propagated up the tree by
+     * incrementing the visit count and adding the value to the total
+     * value of each node.
+     *
+     * @param node The node to start the backpropagation from.
+     * @param result The value of the leaf node.
+     */
     private void backpropagate(MCTSNode<ActionT, SearchStateT> node, double result) {
         System.out.println("Backpropagating...");
         while (node != null) {
@@ -94,6 +182,14 @@ public class MCTS<ActionT, SearchStateT extends SearchState<ActionT, SearchState
         }
     }
 
+    /**
+     * Returns the best action from the given root node.
+     * The best action is determined by the number of visits to each child node.
+     * If no child nodes exist, returns null.
+     *
+     * @param root The root node to find the best action from.
+     * @return The best action from the given root node.
+     */
     private ActionT getBestAction(MCTSNode<ActionT, SearchStateT> root) {
         return root.children.entrySet().stream()
                 .max(Comparator.comparingInt(e -> e.getValue().visitCount))

--- a/src/main/java/edu/washburn/cis/ichabot/search/MCTSNode.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MCTSNode.java
@@ -3,6 +3,16 @@ package edu.washburn.cis.ichabot.search;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A node in the MCTS tree.
+ * Each node has a state, a parent node, the action leading to this node from the parent, and a map of children nodes.
+ * Each node also has a visit count and a total value,
+ * which are used to calculate the average value of the node.
+ * 
+ * @author Hayden Eddy
+ * @version 1.0
+ * @see MCTS
+ */
 public class MCTSNode<ActionT, SearchStateT extends SearchState<ActionT, SearchStateT>> {
     public final SearchStateT state;
     public final MCTSNode<ActionT, SearchStateT> parent;
@@ -11,7 +21,11 @@ public class MCTSNode<ActionT, SearchStateT extends SearchState<ActionT, SearchS
     public int visitCount;
     public double totalValue;
 
-    // Root node constructor
+    /**
+     * Constructor for the root node.
+     * 
+     * @param state The state of the root node, or the initial state of the search problem.
+     */
     public MCTSNode(SearchStateT state) {
         this.state = state;
         this.parent = null;
@@ -21,7 +35,12 @@ public class MCTSNode<ActionT, SearchStateT extends SearchState<ActionT, SearchS
         this.totalValue = 0.0;
     }
 
-    // Child node constructor
+    /**
+     * Constructor for a child node.
+     * @param state the state of the child node
+     * @param parent the parent node
+     * @param action the action leading to this node from the parent
+     */
     public MCTSNode(SearchStateT state, MCTSNode<ActionT, SearchStateT> parent, ActionT action) {
         this.state = state;
         this.parent = parent;
@@ -31,14 +50,35 @@ public class MCTSNode<ActionT, SearchStateT extends SearchState<ActionT, SearchS
         this.totalValue = 0.0;
     }
 
+    /**
+     * Returns true if the node has been fully expanded, meaning that all possible
+     * actions from the node have been explored. This is determined by checking if
+     * the number of children is equal to the number of possible actions from the
+     * node.
+     * @return true if the node is fully expanded, false otherwise
+     */
     public boolean isFullyExpanded() {
         return children.size() == state.actions().size();
     }
 
+    /**
+     * Adds a child node to the current node.
+     * The child node is associated with the given action.
+     * This is used to expand the current node, by generating a new child node for
+     * each possible action from the current node.
+     * @param action the action leading to the child node
+     * @param child the child node to add
+     */
     public void addChild(ActionT action, MCTSNode<ActionT, SearchStateT> child) {
         children.put(action, child);
     }
 
+    /**
+     * Returns the average value of the node.
+     * This is calculated by dividing the total value of the node by the number of visits.
+     * If the node has not been visited, the average value is 0.
+     * @return the average value of the node
+     */
     public double getAverageValue() {
         return visitCount == 0 ? 0 : totalValue / visitCount;
     }

--- a/src/main/java/edu/washburn/cis/ichabot/search/MCTSNode.java
+++ b/src/main/java/edu/washburn/cis/ichabot/search/MCTSNode.java
@@ -1,0 +1,45 @@
+package edu.washburn.cis.ichabot.search;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MCTSNode<ActionT, SearchStateT extends SearchState<ActionT, SearchStateT>> {
+    public final SearchStateT state;
+    public final MCTSNode<ActionT, SearchStateT> parent;
+    public final ActionT action; // Action leading to this node from parent
+    public final Map<ActionT, MCTSNode<ActionT, SearchStateT>> children;
+    public int visitCount;
+    public double totalValue;
+
+    // Root node constructor
+    public MCTSNode(SearchStateT state) {
+        this.state = state;
+        this.parent = null;
+        this.action = null;
+        this.children = new HashMap<>();
+        this.visitCount = 0;
+        this.totalValue = 0.0;
+    }
+
+    // Child node constructor
+    public MCTSNode(SearchStateT state, MCTSNode<ActionT, SearchStateT> parent, ActionT action) {
+        this.state = state;
+        this.parent = parent;
+        this.action = action;
+        this.children = new HashMap<>();
+        this.visitCount = 0;
+        this.totalValue = 0.0;
+    }
+
+    public boolean isFullyExpanded() {
+        return children.size() == state.actions().size();
+    }
+
+    public void addChild(ActionT action, MCTSNode<ActionT, SearchStateT> child) {
+        children.put(action, child);
+    }
+
+    public double getAverageValue() {
+        return visitCount == 0 ? 0 : totalValue / visitCount;
+    }
+}


### PR DESCRIPTION
The changes in this fork/pull request are:

1. Addition/Implementation of MCTS and MCTSNode in the Search package. These classes represent the Monte Carlo Tree Search, and work in conjunction with the current Ichabot SearchState code structure. They are parameterized with extensions of SearchState, which includes classes that extend MinimaxSearchState.
2. Documention of the MCTS and MCTSNode classes in javadoc format.
3. A simple change to Reversi that allowed me to test if this implementation worked for current Ichabot implementations of MinimaxSearchState. It does work. I know that you left it to us to implement determining if a node is terminal for Reversi, but I had to do it for this test to work here. Simply reversing these changes would be fine.